### PR TITLE
Issue/add positioner

### DIFF
--- a/abb_example/config/m1_workcell.srdf
+++ b/abb_example/config/m1_workcell.srdf
@@ -28,6 +28,16 @@
         <joint name="positioner_joint_1" />
     </group>
 
+    <group_opw group="manipulator" a1="0.15" a2="-0.115" b="0" c1="0.445" c2="0.7" c3="0.795" c4="0.085" offsets="0.000000 0.000000 -1.570796 0.000000 0.000000 0.000000" sign_corrections="1 1 1 1 1 1"/>
+
+    <group_rep group="manipulator_aux">
+      <manipulator group="manipulator" ik_solver="OPWInvKin" reach="1.8"/>
+      <positioner group="positioner_only">
+        <joint name="positioner_base_joint" resolution="0.1"/>
+        <joint name="positioner_joint_1" resolution="0.1"/>
+      </positioner>
+    </group_rep>
+
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="base_link" link2="link_1" reason="Adjacent" />
     <disable_collisions link1="base_link" link2="link_2" reason="Never" />

--- a/abb_example/src/abb_planner_example.cpp
+++ b/abb_example/src/abb_planner_example.cpp
@@ -146,26 +146,26 @@ bool AbbPlannerExample::run()
   joint_names.push_back("joint_4");
   joint_names.push_back("joint_5");
   joint_names.push_back("joint_6");
-//  joint_names.push_back("positioner_base_joint");
-//  joint_names.push_back("positioner_joint_1");
+  joint_names.push_back("positioner_base_joint");
+  joint_names.push_back("positioner_joint_1");
 
 
-  Eigen::VectorXd joint_start_pos(6);
+  Eigen::VectorXd joint_start_pos(8);
   joint_start_pos(0) = -0.4;
   joint_start_pos(1) = 0.2762;
   joint_start_pos(2) = 0.0;
   joint_start_pos(3) = -1.3348;
   joint_start_pos(4) = 0.0;
   joint_start_pos(5) = 1.4959;
-//  joint_start_pos(6) = 0;
-//  joint_start_pos(7) = 0;
+  joint_start_pos(6) = 0;
+  joint_start_pos(7) = 0;
 
   env_->setState(joint_names, joint_start_pos);
 
   // Create manipulator information for program
   ManipulatorInfo mi;
   mi.manipulator = "manipulator_aux";
-  mi.working_frame = "part";
+  mi.working_frame = "positioner_tool0";
   mi.tcp = tesseract_planning::ToolCenterPoint("tool0", false);  // true - indicates this is an external TCP
   // Create Program
   CompositeInstruction program("FREESPACE", CompositeInstructionOrder::ORDERED, mi);

--- a/tesseract/tesseract_srdf/src/group_rep_kinematics.cpp
+++ b/tesseract/tesseract_srdf/src/group_rep_kinematics.cpp
@@ -103,7 +103,7 @@ GroupREPKinematics parseGroupREPKinematics(const tesseract_scene_graph::SceneGra
     // get the chains in the groups
     bool parse_joints_failed = false;
     for (const tinyxml2::XMLElement* joint_xml = positioner_xml->FirstChildElement("joint"); positioner_xml;
-         positioner_xml = positioner_xml->NextSiblingElement("joint"))
+         joint_xml = positioner_xml->NextSiblingElement("joint"))
     {
       if (joint_xml == nullptr)
       {

--- a/tesseract/tesseract_srdf/src/group_rop_kinematics.cpp
+++ b/tesseract/tesseract_srdf/src/group_rop_kinematics.cpp
@@ -103,7 +103,7 @@ GroupROPKinematics parseGroupROPKinematics(const tesseract_scene_graph::SceneGra
     // get the chains in the groups
     bool parse_joints_failed = false;
     for (const tinyxml2::XMLElement* joint_xml = positioner_xml->FirstChildElement("joint"); positioner_xml;
-         positioner_xml = positioner_xml->NextSiblingElement("joint"))
+         joint_xml = positioner_xml->NextSiblingElement("joint"))
     {
       if (joint_xml == nullptr)
       {

--- a/trajopt_ros/trajopt_sco/CMakeLists.txt
+++ b/trajopt_ros/trajopt_sco/CMakeLists.txt
@@ -34,6 +34,8 @@ if (NOT APPLE AND NOT WIN32)
   set (HAVE_BPMPD TRUE)
 endif()
 
+set (HAVE_BPMPD FALSE)
+
 if (HAVE_BPMPD)
   add_executable(bpmpd_caller src/bpmpd_caller.cpp)
 


### PR DESCRIPTION
The underlining issue was joint groups currently do not generate a default inverse kinematics solver. This is a known issue but usually, for use cases, we typically have a custom inverse kinematics for joint groups. I found a bug when adding the custom inverse kinematics solver which I currently creating a unit test and fix for Tesseract but it is included in this PR. 